### PR TITLE
Update to work with Crystal version 0.32

### DIFF
--- a/src/open-simplex-noise.cr
+++ b/src/open-simplex-noise.cr
@@ -1,7 +1,10 @@
+require "big"
 require "./open-simplex-noise/*"
+
 
 class OpenSimplexNoise
   def initialize(seed : Int64 = DEFAULT_SEED)
+    big_seed = BigInt.new seed
     # Initiate the class and generate permutation arrays from a seed number.
 
     # Initializes the class using a permutation array generated from a 64-bit seed.
@@ -11,14 +14,14 @@ class OpenSimplexNoise
     @perm_grad_index_3d = Array(Int32).new(256, 0)
 
     source = (0...256).to_a
-    3.times { seed = seed * 6364136223846793005 + 1442695040888963407 }
+    3.times { big_seed = big_seed * 6364136223846793005 + 1442695040888963407 }
 
     source.reverse.each do |i|
-      seed = seed * 6364136223846793005 + 1442695040888963407
-      r = (seed + 31) % (i + 1)
+      big_seed = big_seed * 6364136223846793005 + 1442695040888963407
+      r = (big_seed + 31) % (i + 1)
       r += i + 1 if r < 0
       @perm[i] = source[r]
-      @perm_grad_index_3d[i] = (@perm[i] % (GRADIENTS_3D.size / 3)) * 3
+      @perm_grad_index_3d[i] = ((@perm[i].to_f64 % (GRADIENTS_3D.size / 3)) * 3).to_i32
       source[r] = source[i]
     end
   end


### PR DESCRIPTION
In the previous version there were some errors with types that prevented the noise function from initializing correctly. Seed is switched to a big number to prevent overflow and some type changes in setting the perm_grad_index3d.